### PR TITLE
- Bug fix: El número de hilos exportadores ya no afectan al número de invariantes

### DIFF
--- a/src/main/Exportador.java
+++ b/src/main/Exportador.java
@@ -1,17 +1,17 @@
 package main;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Exportador implements Runnable{
     
     final Monitor monitor;
     String threadName;
-    private int contador;
+    private static final AtomicInteger contador = new AtomicInteger(0);
     private final int max;
 
     public Exportador(Monitor monitor, int cantidad) {
         this.monitor = monitor;
-        contador = 0;
         max = cantidad;
     }
 
@@ -20,24 +20,28 @@ public class Exportador implements Runnable{
         threadName = Thread.currentThread().getName();
         System.out.printf("%s inicializado\n", threadName);
 
-        while (contador < max && !monitor.finalizarquestion()){
+        while (contador.get() < max && !monitor.finalizarquestion()){
             //System.out.println(threadName + ": Buscando imagen para exportar.");
             Imagen img = monitor.startexporte();
 
+            if(monitor.finalizarquestion()){
+                break;
+            }
+
             monitor.finishexport(img);
             //System.out.println(threadName + ": Imagen exportada exitósamente.");
-            contador++;
+            contador.incrementAndGet();
 
-             try{
+            /*try{
                 TimeUnit.MILLISECONDS.sleep(0);
             } catch(InterruptedException e){
                 e.printStackTrace();
-            }
+            }*/
         }
         monitor.finalizar();
     }
 
     public int getContador(){
-        return contador;
+        return contador.get();
     }
 }

--- a/src/main/Monitor.java
+++ b/src/main/Monitor.java
@@ -258,6 +258,11 @@ public class Monitor {
                 System.out.println("Monitor: interrupted while trying to acquire s_exporta: " + e);
             }
             getmutex();
+            if(invariantescompletados){
+                s_exporta.release();
+                mutex.release();
+                return null;
+            }
             if(petri.issensibilizada(15))
                 break;
             s_exporta.release();
@@ -290,8 +295,10 @@ public class Monitor {
 
     public void finalizar(){
         invariantescompletados = true;
+        getmutex();
         System.out.println("Programa finalizado con: " + getBufferExportadas() + " invariantes");
         petri.imprimircontador();
+        mutex.release();
         //System.out.print(petri.getSecuencia());
     }
 


### PR DESCRIPTION
Corregí el bug que hacía que se impriman invariantes de más al tener multiples hilos exportadores haciendo la variable **contador** un AtomicInteger estático. También tuve que realizar cambios mínimos en los métodos **finalizar** y **startexporte** de la clase Monitor para que no los hilos no queden atrapados en el while true ni se superponga el texto del final del programa impreso por varios hilos.